### PR TITLE
Enable forcing commercial metrics

### DIFF
--- a/packages/ab-core/src/types.ts
+++ b/packages/ab-core/src/types.ts
@@ -89,6 +89,7 @@ export interface ABTest {
 	successMeasure: string;
 	audienceCriteria: string;
 	showForSensitive?: boolean;
+	commercialMetrics?: boolean;
 	idealOutcome?: string;
 	dataLinkNames?: string;
 	variants: ReadonlyArray<Variant>;


### PR DESCRIPTION
## What does this change?

Adds a new optional property to ABTests:

```ts
export interface ABTest = {
  /* … */
  commercialMetrics?: boolean;
  /* … */
}
```

## How to test

Release on NPM and integrate in a consumer.

## How can we measure success?

We can record all commercial metrics for specific tests

## Have we considered potential risks?

n/a

## Images

n/a

## Accessibility

n/a