### PR TITLE
Enforce return type on variant test function

### DIFF
--- a/packages/ab-core/src/types.ts
+++ b/packages/ab-core/src/types.ts
@@ -71,7 +71,7 @@ type ListenerFunction = (f: () => void) => void;
 
 export interface Variant {
 	id: string;
-	test: (x: Record<string, unknown>) => void;
+	test: (x: Record<string, unknown>) => void | undefined;
 	campaignCode?: string;
 	canRun?: () => boolean;
 	impression?: ListenerFunction;


### PR DESCRIPTION
## What does this change?

change `variant.test` return type to `void | undefined` from `void`

## Why

This will prevent unintentionally returning something from the test function, as the void return type on its own does allow the function to return anything (it's just ignored by the compiler), adding `undefined` will allow it to only return undefined or nothing.

See: https://www.typescriptlang.org/docs/handbook/2/functions.html#return-type-void

This will potentially mitigate a footgun scenario where by _someone_ might pass a function that returns a function instead of a function 🙃
